### PR TITLE
[fix] funding remainPieces update 필드명 오류 수정

### DIFF
--- a/src/main/java/com/pieceofcake/product_read_service/funding/infrastructure/FundingReadMongoRepositoryImpl.java
+++ b/src/main/java/com/pieceofcake/product_read_service/funding/infrastructure/FundingReadMongoRepositoryImpl.java
@@ -49,7 +49,7 @@ public class FundingReadMongoRepositoryImpl implements FundingReadMongoRepositor
     @Override
     public void updateRemainPieces(String fundingUuid, int remainPieces) {
         Query query = new Query(Criteria.where("fundingRead.fundingUuid").is(fundingUuid));
-        Update update = new Update().set("fundingRead.remainPieces", remainPieces);
+        Update update = new Update().set("fundingRead.remainingPieces", remainPieces);
         mongoTemplate.updateFirst(query, update, ProductRead.class);
     }
 }


### PR DESCRIPTION
## 📝작업 내용

> 공모의 남은 조각 수 갱신 오류 발생
> remainPieces → remainingPieces로 수정
